### PR TITLE
Merge `master` into `main` branch to include commit dropping `bottle ::unneeded` from formulas

### DIFF
--- a/command-execution-timer.rb
+++ b/command-execution-timer.rb
@@ -5,8 +5,6 @@ class CommandExecutionTimer < Formula
   sha256 "71a837305e34ccbc15e9384992257857e78cdc30bbb7b2372f0f62dfe2f66dd4"
   head "https://github.com/olets/command-execution-timer.git", :branch => "main"
 
-  bottle :unneeded
-
   def install
     pkgshare.install "command-execution-timer.zsh"
   end

--- a/git-prompt-kit.rb
+++ b/git-prompt-kit.rb
@@ -5,8 +5,6 @@ class GitPromptKit < Formula
   sha256 "f8ffd516981dd2e09a5334abb9a528b0595acde329197b5e46340e1645813fc2"
   head "https://github.com/olets/git-prompt-kit.git", :branch => "main"
 
-  bottle :unneeded
-
   def install
     pkgshare.install "git-prompt-kit.zsh"
   end

--- a/git-replay.rb
+++ b/git-replay.rb
@@ -5,7 +5,6 @@ class GitReplay < Formula
   sha256 "4e1905dc30b95b1443a0a2211563b232474709bc26c80abebbb5de4b6060ca59"
   head "https://github.com/olets/git-replay.git", branch: "main"
 
-  bottle :unneeded
   depends_on "yq"
 
   def install

--- a/nitro-zsh-completions.rb
+++ b/nitro-zsh-completions.rb
@@ -5,8 +5,6 @@ class NitroZshCompletions < Formula
   sha256 "b11ee3a3012880e615fe8cabbe012cdc6bcf750f07939af922fb62fed06144bc"
   head "https://github.com/olets/nitro-zsh-completions.git", branch: "main"
 
-  bottle :unneeded
-
   def install
     pkgshare.install "completions/_nitro"
   end

--- a/zsh-abbr.rb
+++ b/zsh-abbr.rb
@@ -5,8 +5,6 @@ class ZshAbbr < Formula
   sha256 "108d7edcb34107e745825d13b68ca17cb56e73fe2e25a786323141f482feb7ad"
   head "https://github.com/olets/zsh-abbr.git", branch: "main"
 
-  bottle :unneeded
-
   def install
     pkgshare.install "zsh-abbr.zsh"
 

--- a/zsh-test-runner.rb
+++ b/zsh-test-runner.rb
@@ -5,8 +5,6 @@ class ZshTestRunner < Formula
   sha256 "2495aeee8a17a4ca8a9decb90616b3084368cb41d301eb452ddaacdb64a0acea"
   head "https://github.com/olets/zsh-test-runner.git", branch: "main"
 
-  bottle :unneeded
-
   def install
     pkgshare.install "ztr.zsh"
 

--- a/zsh-window-title.rb
+++ b/zsh-window-title.rb
@@ -5,8 +5,6 @@ class ZshWindowTitle < Formula
   sha256 "739b3a9cb76597bb3adab8694b3318cb8fec6dcca20f50d7806820129961164b"
   head "https://github.com/olets/zsh-window-title.git", branch: "main"
 
-  bottle :unneeded
-
   def install
     pkgshare.install "zsh-window-title.zsh"
 


### PR DESCRIPTION
### Description of PR: What it Solves

It seems that this repository confusingly contains both a `main` and `master` branch. Even though your original commit of cd6a80ee1c80946591b404caff5eef24eaa2ad9f already removed the deprecated `bottle ::unneeded` usages from all formulas (which *__will__* properly silence the warning messages from `brew` that were described in issue olets/homebrew-tap#2), such changes were only pushed to the `master` branch.

Due to this repository containing both a `main` and `master` branch, in combination with the *"primary branch" precedence handling* of `brew`, *which __favors a `main` branch__ if one exists*, as well as the commit at issue only being pushed to `master` __*and not `main`*__, the changes from cd6a80ee1c80946591b404caff5eef24eaa2ad9f fixing the deprecation warning at issue in #2 are entirely unavailable to those who tapped this repository: __`brew` pulls only from the `main` branch since it exists.__

### Options for Issue Resolution

I have ultimately been able to surmise two meaningful solutions to resolve this issue *and avoid a reoccurrence*:

1. __Merge this PR__ (containing a fast-forward merge of your `master` branch into `main`) *and* __remove the `master` branch__ entirely from this repository. Such actions would help avoid accidentally pushing important fixes to `master` again in the future.

2. __Close this PR__ *and* __remove the `main` branch__ instead, in which case I *__assume__ `brew` will return to using the `master` branch automatically*. It is important for me to be clear that I have never tested this specific "primary branch" reversion operation with `brew`, (moving back to the `master` branch from `main`), and have only ever changed the "primary branch" in the other direction (from `master` to `main`).

<details>

__<summary>[Click to Expand] IMPORTANT: A disclaimer as to possible complications of either branch's deletion.</summary>__

I do not know *how `brew` will react with `master` deleted for those who originally tapped your repository when `master` was the "primary branch"* (before `main` existed), nor do I know *how `brew` will react with `main` deleted for those who more-recently tapped your repository when `main` was the "primary branch"*. As such, unless `brew` gracefully handles one of the scenarios, both branches may need to remain in sync to support all end-users, though I do not know how (or even if) such can be accomplished directly within GitHub's repository settings.

</details>

<details>

__<summary>[Click to Expand] Example of a possible branch sync option using Git hooks.</summary>__

You *could* use a git post-commit hook in `.git/hooks/post-commit` to effectively sync the two branches with something like this (though it'd require remembering to always push using `git push --all` so both `main` and `master` are pushed to the remote):

```bash
#!/bin/sh

#
# assuming you locally work using the `main` branch, then the below script will perform the
# following operations immediately after each `git commit` call on the `main` branch:
#
#  - checkout `master`
#  - merge `main` into `master` (could instead use `rebase` if preferred)
#  - re-checkout `main` for you to continue working
#
# such would merge any `main` commit(s) to `master` automatically, though you would still need
# to remember to always use `git push --all` when pushing changes to GitHub (or other remotes),
# as without `--all` only the active `main` branch's changes will actually be pushed
#


git checkout master
git merge main
git checkout main
```
</details>

### Relation and Response to Issue #2

Hopefully, this PR better explains [my comment from issue #2](https://github.com/olets/homebrew-tap/issues/2#issuecomment-950045137), where I was continuing to receive the deprecation message originally described in that issue, despite a fix having already been committed.

<details>

__<summary>[Click to Expand] NOTE: A response to @olets [reply comment to me](https://github.com/olets/homebrew-tap/issues/2#issuecomment-950045865) in issue #2.</summary>__

My incorrect mentioning of `iproute2mac` was due to not being aware that the tap deprecation message described in that issue appears for *every single invocation of the `brew` command*, even when issuing `brew` operations entirely unrelated to this tap or the formulas contained within it. Such behavior seems entirely unreasonable to me, but neither you nor I built or maintain `brew`, so perhaps a reason exists for verbosely warning about taps/formulas not related to operations actually executed (I just can't seem to come up with such a reason :-)...

</details>

### Original Commit Message for Commit cd6a80ee1c80946591b404caff5eef24eaa2ad9f Fix

> This will be deprecated in Hombrew v3.3.0 or v4.0.0
>
> Safe to remove now because it was only relevant to Homebrew/core
>
> Ref https://github.com/Homebrew/brew/commit/f65d525693a45c8e4c2ebc1452080f08c363ee15#diff-f12455e8eb757e3223300c7c544b5b752394173c2a9bb0440443d5673b151fb3